### PR TITLE
Add flag to read Keycloak-generated keys

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>= 1.21.5'
+          go-version: '>= 1.23.0'
       
       - name: build
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.25-alpine AS build
+FROM --platform=${BUILDPLATFORM} golang:1.26-alpine AS build
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
@@ -15,7 +15,7 @@ COPY . .
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build  -ldflags="-w -s" -o did-helper .
 
-FROM --platform=${TARGETPLATFORM} alpine:3.21
+FROM alpine:3.21
 
 ENV KEY_TYPE_TO_GENERATE="EC"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build  -ldflags="-w -s" -o did-helper .
 
-FROM alpine:3.21
+FROM alpine:3.23
 
 ENV KEY_TYPE_TO_GENERATE="EC"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM --platform=${BUILDPLATFORM} golang:1.25-alpine AS build
 
 ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -14,7 +15,7 @@ COPY . .
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build  -ldflags="-w -s" -o did-helper .
 
-FROM --platform=${BUILDPLATFORM} alpine:3.21
+FROM --platform=${TARGETPLATFORM} alpine:3.21
 
 ENV KEY_TYPE_TO_GENERATE="EC"
 

--- a/README.md
+++ b/README.md
@@ -129,3 +129,36 @@ Usage of ./did-helper:
   -server
     	Run a server with /did.json and /.well-known/tls.crt endpoints. (env RUN_SERVER)
 ```
+
+## Keycloak Integration
+
+The helper supports reading key material directly from a [Keycloak](https://www.keycloak.org/) instance. When configured with `-didType=keycloak`, the server exposes DID documents based on Keycloak realms using the following URL pattern:
+
+```
+/{realm}/did.json
+```
+
+Where `{realm}` is the **base64-encoded** name of the Keycloak realm. The helper will decode it, fetch the JWKS from the corresponding Keycloak realm and build the DID document accordingly.
+
+### Configuration
+
+| Parameter | Env Var | Description |
+|-----------|---------|-------------|
+| `-didType=keycloak` | `DID_TYPE=keycloak` | Enables Keycloak mode |
+| `-keycloakHost` | `KEYCLOAK_HOST` | Base URL of the Keycloak instance (e.g., `https://keycloak.example.com`) |
+
+### Example
+
+```shell
+./did-helper -didType=keycloak -keycloakHost=https://keycloak.example.com -server
+```
+
+Once running, the DID document for a realm `my-realm` would be available at:
+
+```shell
+# Encode the realm id in base64
+REALM_B64=$(echo -n "my-realm" | base64)
+
+# Request the DID document
+curl http://localhost:8080/${REALM_B64}/did.json
+```

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ The container can be configured, using the following environment-variables:
 | KEY_PATH | Path to the key PEM certificate | string |
 | OUTPUT_FORMAT | Output format for the did result file. | "json", "env", "json_jwk" | "json" |
 | OUTPUT_FILE | File to write the did, format depends on the requested format. Will not write the file if empty. | string | "/cert/did.json" |
-| DID_TYPE | Type of the did to generate. | "key", "jwk" or "web" | "key" |
+| DID_TYPE | Type of the did to generate. | "key", "jwk", "web" or "keycloak" | "key" |
 | KEY_TYPE | Type of the key provided. | "P-256", "P-384" or "ED-25519" | "P-256" |
 | HOST_URL | Base URL where the DID document will be located, excluding 'did.json'. (e.g., https://example.com/alice for https://example.com/alice/did.json). Required for did:web | |
 | CERT_URL | URL to retrieve the public certificate | string | `HOST_URL` + `/.well-known/tls.crt`
 | RUN_SERVER | Run a server with /did.json and /.well-known/tls.crt endpoints | false
 | SERVER_PORT | Server port | 8080 |
+| KEYCLOAK_HOST | Base URL of the Keycloak instance used to fetch JWKS for realm-based DID documents (e.g., `https://keycloak.example.com`). Required when `DID_TYPE=keycloak`. | string | |
+| KEYCLOAK_REALM | Fixed Keycloak realm. When set with `DID_TYPE=keycloak`, serves a static DID document for this realm at the path derived from `HOST_URL`, instead of the dynamic `/{realm}/did.json` pattern. | string | |
+| IGNORE_TLS_VALIDATION | Disable TLS certificate validation when connecting to Keycloak. Do not use in production. | "true", "false" | "false" |
 | KEY_TYPE_TO_GENERATE | Type of the key to be generated. RSA is only supported for did:jwk | "EC", "ED-25519" or "RSA" | "EC" |
 | KEY_ALIAS | Alias for the key inside the keystore | string | "myAlias" |
 | COUNTRY | Country to be set for the created certificate. | string | "DE" |
@@ -128,6 +131,12 @@ Usage of ./did-helper:
     	Server port. Default 8080. (env SERVER_PORT) (default 8080)
   -server
     	Run a server with /did.json and /.well-known/tls.crt endpoints. (env RUN_SERVER)
+  -keycloakHost string
+    	URL of the Keycloak instance used to construct the OIDC discovery and JWKS endpoints for the realms. (env KEYCLOAK_HOST)
+  -keycloakRealm string
+    	Fixed Keycloak realm. When set with didType=keycloak, serves a fixed DID document for this realm at the path derived from hostUrl. (env KEYCLOAK_REALM)
+  -ignoreTlsValidation
+    	Disable TLS validation when connecting to Keycloak. Do not use it in production. (env IGNORE_TLS_VALIDATION) (default false)
 ```
 
 ## Keycloak Integration
@@ -146,6 +155,8 @@ Where `{realm}` is the **base64-encoded** name of the Keycloak realm. The helper
 |-----------|---------|-------------|
 | `-didType=keycloak` | `DID_TYPE=keycloak` | Enables Keycloak mode |
 | `-keycloakHost` | `KEYCLOAK_HOST` | Base URL of the Keycloak instance (e.g., `https://keycloak.example.com`) |
+| `-keycloakRealm` | `KEYCLOAK_REALM` | Fixed realm name. When set, the server exposes a single static DID document at the path derived from `-hostUrl` (e.g., `/my/path/did.json`) instead of the dynamic `/{realm}/did.json` pattern. The certificate is available at `/.well-known/tls.crt` under the same base path. |
+| `-ignoreTlsValidation` | `IGNORE_TLS_VALIDATION` | Disable TLS certificate validation when connecting to Keycloak. Do not use in production. |
 
 ### Example
 

--- a/did/cert_utils.go
+++ b/did/cert_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap"
 	"software.sslmate.com/src/go-pkcs12"
 )
 
@@ -91,4 +92,26 @@ func LoadCertsConfigFromPem(config *Config) (err error) {
 		}
 	}
 	return
+}
+
+func LoadCertificates(config *Config) (err error) {
+	var source string
+	if config.KeyPath != "" || config.CertPath != "" {
+		err = LoadCertsConfigFromPem(config)
+	} else {
+		config.Certificates.PrivateKey, config.Certificates.PublicKey, err = GetCertFromKeyStore(config.KeystorePath, config.KeystorePassword)
+	}
+	if err != nil {
+		zap.L().Sugar().Warnf("Was not able to load certs from %s %s", source, config.KeystorePath, "error", err)
+		return err
+	}
+	return nil
+}
+
+func GetCert(config Config) (certRaw []byte, err error) {
+	pemBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: config.Certificates.PublicKey.Raw,
+	}
+	return pem.EncodeToMemory(pemBlock), nil
 }

--- a/did/did.go
+++ b/did/did.go
@@ -21,22 +21,24 @@ type VerificationMethod struct {
 }
 
 type Config struct {
-	KeystorePath     string       `flag:"keystorePath" default:"" usage:"Path to the keystore to be read."`
-	KeystorePassword string       `flag:"keystorePassword" default:"" usage:"Password for the keystore."`
-	CertPath         string       `flag:"certPath" default:"" usage:"Path to the PEM certificate."`
-	KeyPath          string       `flag:"keyPath" default:"" usage:"Path to the key PEM certificate."`
-	OutputFormat     string       `flag:"outputFormat" default:"json" usage:"Output format for the DID result file. Can be json, env or json_jwk."`
-	OutputFile       string       `flag:"outputFile" default:"" usage:"File to write the DID; will not write if empty."`
-	DidType          string       `flag:"didType" default:"key" usage:"Type of the DID to generate. did:key and did:jwk are supported."`
-	KeyType          string       `flag:"keyType" default:"P-256" usage:"Type of the DID key to be created. Supported: ED-25519, P-256, P-384."`
-	HostUrl          string       `flag:"hostUrl" default:"" usage:"Base URL where the DID document will be located, excluding 'did.json'."`
-	CertUrl          string       `flag:"certUrl" default:"" usage:"URL to retrieve the public certificate. Defaults to 'hostUrl' + /.well-known/tls.crt"`
-	RunServer        bool         `flag:"server" default:"false" usage:"Run a server with /did.json and /.well-known/tls.crt endpoints."`
-	ServerPort       int          `flag:"port" default:"8080" usage:"Server port. Default 8080."`
-	Certificates     Certificates `flag:""`
+	KeystorePath        string       `flag:"keystorePath" default:"" usage:"Path to the keystore to be read."`
+	KeystorePassword    string       `flag:"keystorePassword" default:"" usage:"Password for the keystore."`
+	CertPath            string       `flag:"certPath" default:"" usage:"Path to the PEM certificate."`
+	KeyPath             string       `flag:"keyPath" default:"" usage:"Path to the key PEM certificate."`
+	OutputFormat        string       `flag:"outputFormat" default:"json" usage:"Output format for the DID result file. Can be json, env or json_jwk."`
+	OutputFile          string       `flag:"outputFile" default:"" usage:"File to write the DID; will not write if empty."`
+	DidType             string       `flag:"didType" default:"key" usage:"Type of the DID to generate. did:key and did:jwk are supported."`
+	KeyType             string       `flag:"keyType" default:"P-256" usage:"Type of the DID key to be created. Supported: ED-25519, P-256, P-384."`
+	HostUrl             string       `flag:"hostUrl" default:"" usage:"Base URL where the DID document will be located, excluding 'did.json'."`
+	CertUrl             string       `flag:"certUrl" default:"" usage:"URL to retrieve the public certificate. Defaults to 'hostUrl' + /.well-known/tls.crt"`
+	RunServer           bool         `flag:"server" default:"false" usage:"Run a server with /did.json and /.well-known/tls.crt endpoints."`
+	ServerPort          int          `flag:"port" default:"8080" usage:"Server port. Default 8080."`
+	Certificates        Certificates `flag:""`
+	KeycloakHost        string       `flag:"keycloakHost" usage:"URL of the Keycloak instance used to construct the OIDC discovery and JWKS endpoints for the realms"`
+	IgnoreTlsValidation bool         `flag:"ignoreTlsValidation" default:"false" usage:"Disable TLS validation. Do not use it in production"`
 }
 
 type Certificates struct {
 	PublicKey  *x509.Certificate
-	PrivateKey interface{}
+	PrivateKey any
 }

--- a/did/did.go
+++ b/did/did.go
@@ -35,6 +35,7 @@ type Config struct {
 	ServerPort          int          `flag:"port" default:"8080" usage:"Server port. Default 8080."`
 	Certificates        Certificates `flag:""`
 	KeycloakHost        string       `flag:"keycloakHost" usage:"URL of the Keycloak instance used to construct the OIDC discovery and JWKS endpoints for the realms"`
+	KeycloakRealm       string       `flag:"keycloakRealm" usage:"Fixed Keycloak realm. When set with didType=keycloak, serves a fixed DID document for this realm at the path derived from hostUrl."`
 	IgnoreTlsValidation bool         `flag:"ignoreTlsValidation" default:"false" usage:"Disable TLS validation. Do not use it in production"`
 }
 

--- a/did/did_document.go
+++ b/did/did_document.go
@@ -11,10 +11,13 @@ func NewDIDTransformer() *DIDTransformer {
 }
 
 func (t *DIDTransformer) TransformJWKSToDID(jwks *JWKS, host string, realm string) (map[string]any, error) {
+	didID := fmt.Sprintf("did:web:%s:%s", host, realm)
+	return t.TransformJWKSToDIDByID(jwks, didID)
+}
+
+func (t *DIDTransformer) TransformJWKSToDIDByID(jwks *JWKS, didID string) (map[string]any, error) {
 	var verificationMethods []map[string]any
 	var keyIDs []string
-
-	didID := fmt.Sprintf("did:web:%s:%s", host, realm)
 
 	for _, key := range jwks.Keys {
 		if key.Use == "sig" {

--- a/did/did_document.go
+++ b/did/did_document.go
@@ -1,13 +1,21 @@
 package did
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
-type DIDTransformer struct{}
+type DIDTransformer struct {
+	Logger *zap.Logger
+}
 
-func NewDIDTransformer() *DIDTransformer {
-	return &DIDTransformer{}
+func NewDIDTransformer(logger *zap.Logger) *DIDTransformer {
+	return &DIDTransformer{Logger: logger}
 }
 
 func (t *DIDTransformer) TransformJWKSToDID(jwks *JWKS, host string, realm string) (map[string]any, error) {
@@ -23,20 +31,31 @@ func (t *DIDTransformer) TransformJWKSToDIDByID(jwks *JWKS, didID string) (map[s
 		if key.Use == "sig" {
 			currentKeyID := fmt.Sprintf("%s#%s", didID, key.Kid)
 
+			if key.Kty == "RSA" && (key.N == "" || key.E == "") && len(key.X5c) > 0 {
+				derBytes, err := base64.StdEncoding.DecodeString(key.X5c[0])
+				if err != nil {
+					t.Logger.Warn("Failed to decode x5c for RSA key", zap.String("kid", key.Kid), zap.Error(err))
+				} else if cert, err := x509.ParseCertificate(derBytes); err != nil {
+					t.Logger.Warn("Failed to parse x5c certificate for RSA key", zap.String("kid", key.Kid), zap.Error(err))
+				} else if rsaPub, ok := cert.PublicKey.(*rsa.PublicKey); !ok {
+					t.Logger.Warn("x5c does not contain RSA public key", zap.String("kid", key.Kid))
+				} else {
+					key.N = base64.RawURLEncoding.EncodeToString(rsaPub.N.Bytes())
+					eBytes := make([]byte, 4)
+					binary.BigEndian.PutUint32(eBytes, uint32(rsaPub.E))
+					for len(eBytes) > 1 && eBytes[0] == 0 {
+						eBytes = eBytes[1:]
+					}
+					key.E = base64.RawURLEncoding.EncodeToString(eBytes)
+					t.Logger.Info("Recovered n/e from x5c", zap.String("kid", key.Kid))
+				}
+			}
+
 			vm := map[string]any{
-				"id":         currentKeyID,
-				"type":       "JsonWebKey2020",
-				"controller": didID,
-				"publicKeyJwk": map[string]interface{}{
-					"kty":      key.Kty,
-					"crv":      key.Crv,
-					"x":        key.X,
-					"y":        key.Y,
-					"alg":      key.Alg,
-					"kid":      key.Kid,
-					"x5c":      key.X5c,
-					"x5t#S256": key.X5tS256,
-				},
+				"id":           currentKeyID,
+				"type":         "JsonWebKey2020",
+				"controller":   didID,
+				"publicKeyJwk": key,
 			}
 
 			verificationMethods = append(verificationMethods, vm)

--- a/did/did_document.go
+++ b/did/did_document.go
@@ -1,0 +1,59 @@
+package did
+
+import (
+	"fmt"
+)
+
+type DIDTransformer struct{}
+
+func NewDIDTransformer() *DIDTransformer {
+	return &DIDTransformer{}
+}
+
+func (t *DIDTransformer) TransformJWKSToDID(jwks *JWKS, host string, realm string) (map[string]any, error) {
+	var verificationMethods []map[string]any
+	var keyIDs []string
+
+	didID := fmt.Sprintf("did:web:%s:%s", host, realm)
+
+	for _, key := range jwks.Keys {
+		if key.Use == "sig" {
+			currentKeyID := fmt.Sprintf("%s#%s", didID, key.Kid)
+
+			vm := map[string]any{
+				"id":         currentKeyID,
+				"type":       "JsonWebKey2020",
+				"controller": didID,
+				"publicKeyJwk": map[string]interface{}{
+					"kty":      key.Kty,
+					"crv":      key.Crv,
+					"x":        key.X,
+					"y":        key.Y,
+					"alg":      key.Alg,
+					"kid":      key.Kid,
+					"x5c":      key.X5c,
+					"x5t#S256": key.X5tS256,
+				},
+			}
+
+			verificationMethods = append(verificationMethods, vm)
+			keyIDs = append(keyIDs, currentKeyID)
+		}
+	}
+
+	if len(verificationMethods) == 0 {
+		return nil, fmt.Errorf("no signing keys found in JWKS")
+	}
+
+	didDocument := map[string]any{
+		"@context": []string{
+			"https://www.w3.org/ns/did/v1",
+		},
+		"id":                 didID,
+		"verificationMethod": verificationMethods,
+		"assertionMethod":    keyIDs,
+		"authentication":     keyIDs,
+	}
+
+	return didDocument, nil
+}

--- a/did/did_generator.go
+++ b/did/did_generator.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"net/url"
 	"strings"
@@ -17,22 +16,6 @@ import (
 	"github.com/trustbloc/kms-go/doc/util/fingerprint"
 	"go.uber.org/zap"
 )
-
-func LoadCertificates(config *Config) (err error) {
-
-	var source string
-	if config.KeyPath != "" || config.CertPath != "" {
-		err = LoadCertsConfigFromPem(config)
-	} else {
-		config.Certificates.PrivateKey, config.Certificates.PublicKey, err = GetCertFromKeyStore(config.KeystorePath, config.KeystorePassword)
-	}
-
-	if err != nil {
-		zap.L().Sugar().Warnf("Was not able to load certs from %s %s", source, config.KeystorePath, "error", err)
-		return err
-	}
-	return nil
-}
 
 func GetDIDKey(config Config) (did string, err error) {
 
@@ -136,16 +119,6 @@ func GenerateJWK(config Config) (jwkKey jwk.Key, err error) {
 	}
 
 	return
-}
-
-func GetCert(config Config) (certRaw []byte, err error) {
-
-	pemBlock := &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: config.Certificates.PublicKey.Raw,
-	}
-
-	return pem.EncodeToMemory(pemBlock), nil
 }
 
 func generateJwk(cert *x509.Certificate) (jwkKey jwk.Key, err error) {

--- a/did/did_server.go
+++ b/did/did_server.go
@@ -1,0 +1,77 @@
+package did
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type DidServer struct {
+	BaseServer
+	DidJSONContent string
+	TlsCRTContent  string
+}
+
+func NewDidServer(didJSON string, tlsCRT string, port int, basepath string, didFilename string) *DidServer {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logger: %v", err)
+	}
+	mux := http.NewServeMux()
+
+	didPath := buildDidPath(basepath, didFilename)
+	certPath := strings.TrimSuffix(basepath, "/") + "/.well-known/tls.crt"
+
+	s := &DidServer{
+		DidJSONContent: didJSON,
+		TlsCRTContent:  tlsCRT,
+		BaseServer: BaseServer{
+			Logger: logger,
+			Server: &http.Server{
+				Addr:         fmt.Sprintf(":%d", port),
+				Handler:      mux,
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 10 * time.Second,
+			},
+		},
+	}
+	logger.Info("Base path: " + basepath)
+	logger.Info("Server initialized", zap.String("didPath", didPath), zap.String("certPath", certPath))
+	mux.HandleFunc(didPath, s.handleDidJSON)
+	mux.HandleFunc(certPath, s.handleTlsCRT)
+
+	return s
+}
+
+func (s *DidServer) handleDidJSON(w http.ResponseWriter, r *http.Request) {
+	s.Logger.Info("Request received",
+		zap.String("path", r.URL.Path),
+		zap.String("method", r.Method),
+		zap.String("remote_addr", r.RemoteAddr),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(s.DidJSONContent)); err != nil {
+		s.Logger.Error("Error writing response for /did.json", zap.Error(err))
+	} else {
+		s.Logger.Debug("Response sent successfully", zap.Int("status", http.StatusOK))
+	}
+}
+
+func (s *DidServer) handleTlsCRT(w http.ResponseWriter, r *http.Request) {
+	s.Logger.Info("Request received", zap.String("path", r.URL.Path))
+
+	w.Header().Set("Content-Type", "application/x-x509-ca-cert")
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write([]byte(s.TlsCRTContent)); err != nil {
+		s.Logger.Error("Error writing response for /tls.crt", zap.Error(err))
+	} else {
+		s.Logger.Debug("Response sent successfully", zap.Int("status", http.StatusOK))
+	}
+}

--- a/did/keycloak_client.go
+++ b/did/keycloak_client.go
@@ -1,0 +1,35 @@
+package did
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type KeycloakClient struct {
+	Host                string
+	IgnoreTlsValidation bool
+}
+
+func (c *KeycloakClient) FetchJWKS(realm string) (*JWKS, int, error) {
+	keycloakURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", c.Host, realm)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: c.IgnoreTlsValidation}, //nolint:gosec
+	}
+	client := http.Client{Timeout: 5 * time.Second, Transport: tr}
+	resp, err := client.Get(keycloakURL)
+	if err != nil {
+		return nil, http.StatusBadGateway, fmt.Errorf("identity provider unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, fmt.Errorf("realm not found or Keycloak error")
+	}
+	var jwks JWKS
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("invalid response from identity provider")
+	}
+	return &jwks, http.StatusOK, nil
+}

--- a/did/keycloak_server.go
+++ b/did/keycloak_server.go
@@ -1,0 +1,151 @@
+package did
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type KeycloakServer struct {
+	BaseServer
+	Client      *KeycloakClient
+	Realm       string
+	DID         string
+	Transformer *DIDTransformer
+}
+
+// NewKeycloakServer creates a Keycloak-backed DID server.
+// Dynamic mode (realm == ""): registers /{realm}/did.json; realm and DID are derived from each request.
+// Fixed mode (realm != ""): registers a static path from basepath and uses the pre-computed didID.
+func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool, realm, didID, basepath string) *KeycloakServer {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logger: %v", err)
+	}
+	if ignoreTlsValidation {
+		logger.Warn("Ignore TLS Validation is enabled. Do not use it in production")
+	}
+	mux := http.NewServeMux()
+	s := &KeycloakServer{
+		Client:      &KeycloakClient{Host: keycloakHost, IgnoreTlsValidation: ignoreTlsValidation},
+		Realm:       realm,
+		DID:         didID,
+		Transformer: NewDIDTransformer(logger),
+		BaseServer: BaseServer{
+			Logger: logger,
+			Server: &http.Server{
+				Addr:         fmt.Sprintf(":%d", port),
+				Handler:      mux,
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 10 * time.Second,
+			},
+		},
+	}
+
+	if realm == "" {
+		mux.HandleFunc("/{realm}/did.json", s.handlerRealm)
+		mux.HandleFunc("/{realm}/.well-known/tls.crt", s.handlerCert)
+	} else {
+		didPath := buildDidPath(basepath, "did.json")
+		certPath := strings.TrimSuffix(basepath, "/") + "/.well-known/tls.crt"
+		logger.Info("Keycloak fixed realm server initialized",
+			zap.String("realm", realm),
+			zap.String("didPath", didPath),
+			zap.String("certPath", certPath),
+			zap.String("did", didID),
+		)
+		mux.HandleFunc(didPath, s.handlerRealm)
+		mux.HandleFunc(certPath, s.handlerCert)
+	}
+	return s
+}
+
+// resolveRealm returns the realm name: from the fixed config (fixed mode) or decoded from the path (dynamic mode).
+func (s *KeycloakServer) resolveRealm(r *http.Request) (string, error) {
+	if s.Realm != "" {
+		return s.Realm, nil
+	}
+	realm := r.PathValue("realm")
+	if realm == "" {
+		return "", fmt.Errorf("missing realm")
+	}
+	return realm, nil
+}
+
+func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
+	realm, err := s.resolveRealm(r)
+	if err != nil {
+		s.Logger.Warn("Could not resolve realm", zap.Error(err))
+		s.BaseServer.respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var didID string
+	if s.Realm != "" {
+		didID = s.DID
+	} else {
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			host = r.Host
+		}
+		didID = fmt.Sprintf("did:web:%s:%s", host, realm)
+	}
+
+	jwks, statusCode, err := s.Client.FetchJWKS(realm)
+	if err != nil {
+		s.Logger.Error("Failed to fetch JWKS", zap.Error(err), zap.String("realm", realm))
+		s.BaseServer.respondWithError(w, statusCode, err.Error())
+		return
+	}
+
+	didDoc, err := s.Transformer.TransformJWKSToDIDByID(jwks, didID)
+	if err != nil {
+		s.Logger.Warn("Transformation failed", zap.Error(err))
+		s.BaseServer.respondWithError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(didDoc); err != nil {
+		s.Logger.Error("Failed to encode JSON response", zap.Error(err))
+	}
+}
+
+func (s *KeycloakServer) handlerCert(w http.ResponseWriter, r *http.Request) {
+	realm, err := s.resolveRealm(r)
+	if err != nil {
+		s.Logger.Warn("Could not resolve realm", zap.Error(err))
+		s.BaseServer.respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	jwks, statusCode, err := s.Client.FetchJWKS(realm)
+	if err != nil {
+		s.Logger.Error("Failed to fetch JWKS", zap.Error(err), zap.String("realm", realm))
+		s.BaseServer.respondWithError(w, statusCode, err.Error())
+		return
+	}
+
+	for _, key := range jwks.Keys {
+		if key.Use == "sig" && len(key.X5c) > 0 {
+			certDER, err := base64.StdEncoding.DecodeString(key.X5c[0])
+			if err != nil {
+				s.Logger.Error("Failed to decode x5c certificate", zap.Error(err))
+				s.BaseServer.respondWithError(w, http.StatusInternalServerError, "Invalid certificate in JWKS")
+				return
+			}
+			w.Header().Set("Content-Type", "application/x-x509-ca-cert")
+			w.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+			return
+		}
+	}
+	s.BaseServer.respondWithError(w, http.StatusNotFound, "No signing certificate found in JWKS")
+}

--- a/did/server.go
+++ b/did/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 	"syscall"
@@ -84,7 +85,8 @@ func NewDidServer(didJSON string, tlsCRT string, port int, basepath string, didF
 			},
 		},
 	}
-
+	logger.Info("Base path: " + basepath)
+	logger.Info("Server initialized", zap.String("didPath", didPath), zap.String("certPath", certPath))
 	mux.HandleFunc(didPath, s.handleDidJSON)
 	mux.HandleFunc(certPath, s.handleTlsCRT)
 
@@ -195,7 +197,11 @@ func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	didDoc, err := s.Transformer.TransformJWKSToDID(&jwks, r.Host, realm)
+	host, _, err := net.SplitHostPort(r.Host)
+	if err != nil {
+		host = r.Host
+	}
+	didDoc, err := s.Transformer.TransformJWKSToDID(&jwks, host, realm)
 	if err != nil {
 		s.Logger.Warn("Transformation failed", zap.Error(err))
 		s.BaseServer.respondWithError(w, http.StatusNotFound, err.Error())

--- a/did/server.go
+++ b/did/server.go
@@ -2,6 +2,7 @@ package did
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,25 +12,52 @@ import (
 
 	"os/signal"
 
+	"encoding/base64"
+	"encoding/json"
+
 	"go.uber.org/zap"
 )
 
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+type JWK struct {
+	Kid     string   `json:"kid"`
+	Kty     string   `json:"kty"`
+	Alg     string   `json:"alg"`
+	Use     string   `json:"use"`
+	X5c     []string `json:"x5c"`
+	X5t     string   `json:"x5t"`
+	X5tS256 string   `json:"x5t#S256"`
+	Crv     string   `json:"crv"`
+	X       string   `json:"x"`
+	Y       string   `json:"y"`
+}
+
+type BaseServer struct {
+	Server *http.Server
+	Logger *zap.Logger
+}
+type KeycloakServer struct {
+	BaseServer
+	KeycloakHost        string
+	Transformer         *DIDTransformer
+	IgnoreTlsValidation bool
+}
 type DidServer struct {
+	BaseServer
 	DidJSONContent string
 	TlsCRTContent  string
-	Server         *http.Server
-	Logger         *zap.Logger
+}
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
 }
 
 func NewDidServer(didJSON string, tlsCRT string, port int, basepath string, didFilename string) *DidServer {
 	logger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logger: %v", err)
-	}
-	s := &DidServer{
-		DidJSONContent: didJSON,
-		TlsCRTContent:  tlsCRT,
-		Logger:         logger,
 	}
 	basepath = strings.TrimSuffix(basepath, "/")
 	mux := http.NewServeMux()
@@ -43,16 +71,52 @@ func NewDidServer(didJSON string, tlsCRT string, port int, basepath string, didF
 		didPath = basepath + "/" + didFilename
 	}
 
+	s := &DidServer{
+		DidJSONContent: didJSON,
+		TlsCRTContent:  tlsCRT,
+		BaseServer: BaseServer{
+			Logger: logger,
+			Server: &http.Server{
+				Addr:         fmt.Sprintf(":%d", port),
+				Handler:      mux,
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 10 * time.Second,
+			},
+		},
+	}
+
 	mux.HandleFunc(didPath, s.handleDidJSON)
 	mux.HandleFunc(certPath, s.handleTlsCRT)
 
-	s.Server = &http.Server{
-		Addr:         fmt.Sprintf(":%d", port),
-		Handler:      mux,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+	return s
+}
+
+func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool) *KeycloakServer {
+
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logger: %v", err)
+	}
+	if ignoreTlsValidation {
+		logger.Warn("Ignore TLS Validation is enabled. Do not use it in production")
+	}
+	mux := http.NewServeMux()
+	s := &KeycloakServer{
+		KeycloakHost:        keycloakHost,
+		Transformer:         NewDIDTransformer(),
+		IgnoreTlsValidation: ignoreTlsValidation,
+		BaseServer: BaseServer{
+			Logger: logger,
+			Server: &http.Server{
+				Addr:         fmt.Sprintf(":%d", port),
+				Handler:      mux,
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 10 * time.Second,
+			},
+		},
 	}
 
+	mux.HandleFunc("/{realm}/did.json", s.handlerRealm)
 	return s
 }
 
@@ -85,7 +149,66 @@ func (s *DidServer) handleTlsCRT(w http.ResponseWriter, r *http.Request) {
 		s.Logger.Debug("Response sent successfully", zap.Int("status", http.StatusOK))
 	}
 }
-func (s *DidServer) Start() error {
+
+func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
+
+	realmBase64 := r.PathValue("realm")
+	if realmBase64 == "" {
+		s.Logger.Warn("Request received without realm")
+		http.Error(w, "Missing realm", http.StatusBadRequest)
+		return
+	}
+	realmBytes, err := base64.StdEncoding.DecodeString(realmBase64)
+	if err != nil {
+		s.Logger.Warn("Error decoding realm")
+		http.Error(w, "Realm is not a valid realm", http.StatusBadRequest)
+		return
+	}
+	realm := string(realmBytes)
+	keycloakURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", s.KeycloakHost, realm)
+	tr := &http.Transport{
+		// Configuración de TLS para ignorar la verificación
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: s.IgnoreTlsValidation},
+	}
+	client := http.Client{
+		Timeout:   5 * time.Second,
+		Transport: tr,
+	}
+	resp, err := client.Get(keycloakURL)
+	if err != nil {
+		s.Logger.Error("Failed to connect to Keycloak", zap.Error(err), zap.String("url", keycloakURL))
+		s.BaseServer.respondWithError(w, http.StatusBadGateway, "Indentity provider unreachable")
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		s.Logger.Warn("Keycloak returned non-OK status", zap.Int("status", resp.StatusCode), zap.String("realm", realm))
+		s.BaseServer.respondWithError(w, resp.StatusCode, "Realm not found or Keycloak error")
+		return
+	}
+
+	var jwks JWKS
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		s.Logger.Error("Failed to decode JWKS body", zap.Error(err))
+		s.BaseServer.respondWithError(w, http.StatusInternalServerError, "Invalid response from identity provider")
+		return
+	}
+
+	didDoc, err := s.Transformer.TransformJWKSToDID(&jwks, r.Host, realm)
+	if err != nil {
+		s.Logger.Warn("Transformation failed", zap.Error(err))
+		s.BaseServer.respondWithError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(didDoc); err != nil {
+		s.Logger.Error("Failed to encode JSON response", zap.Error(err))
+	}
+}
+
+func (s *BaseServer) Start() error {
 	s.Logger.Info("Starting server", zap.String("address", s.Server.Addr))
 
 	// Create context to listen for OS signals.
@@ -125,7 +248,17 @@ func (s *DidServer) Start() error {
 	return nil
 }
 
-func (s *DidServer) Shutdown(ctx context.Context) error {
+func (s *BaseServer) Shutdown(ctx context.Context) error {
 	s.Logger.Info("Shutting down server...")
 	return s.Server.Shutdown(ctx)
+}
+
+func (s *BaseServer) respondWithError(w http.ResponseWriter, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+
+	json.NewEncoder(w).Encode(ErrorResponse{
+		Error:   http.StatusText(code),
+		Message: message,
+	})
 }

--- a/did/server.go
+++ b/did/server.go
@@ -179,15 +179,11 @@ func (s *KeycloakServer) resolveRealm(r *http.Request) (string, error) {
 	if s.Realm != "" {
 		return s.Realm, nil
 	}
-	realmBase64 := r.PathValue("realm")
-	if realmBase64 == "" {
+	realm := r.PathValue("realm")
+	if realm == "" {
 		return "", fmt.Errorf("missing realm")
 	}
-	realmBytes, err := base64.StdEncoding.DecodeString(realmBase64)
-	if err != nil {
-		return "", fmt.Errorf("realm is not a valid base64 value")
-	}
-	return string(realmBytes), nil
+	return realm, nil
 }
 
 // fetchJWKS fetches and decodes the JWKS from Keycloak for the given realm.

--- a/did/server.go
+++ b/did/server.go
@@ -28,12 +28,14 @@ type JWK struct {
 	Kty     string   `json:"kty"`
 	Alg     string   `json:"alg"`
 	Use     string   `json:"use"`
+	N       string   `json:"n,omitempty"`
+	E       string   `json:"e,omitempty"`
 	X5c     []string `json:"x5c"`
 	X5t     string   `json:"x5t"`
 	X5tS256 string   `json:"x5t#S256"`
-	Crv     string   `json:"crv"`
-	X       string   `json:"x"`
-	Y       string   `json:"y"`
+	Crv     string   `json:"crv,omitempty"`
+	X       string   `json:"x,omitempty"`
+	Y       string   `json:"y,omitempty"`
 }
 
 type BaseServer struct {
@@ -113,7 +115,7 @@ func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool, 
 		KeycloakHost:        keycloakHost,
 		Realm:               realm,
 		DID:                 didID,
-		Transformer:         NewDIDTransformer(),
+		Transformer:         NewDIDTransformer(logger),
 		IgnoreTlsValidation: ignoreTlsValidation,
 		BaseServer: BaseServer{
 			Logger: logger,

--- a/did/server.go
+++ b/did/server.go
@@ -15,6 +15,7 @@ import (
 
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 
 	"go.uber.org/zap"
 )
@@ -127,14 +128,18 @@ func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool, 
 
 	if realm == "" {
 		mux.HandleFunc("/{realm}/did.json", s.handlerRealm)
+		mux.HandleFunc("/{realm}/.well-known/tls.crt", s.handlerCert)
 	} else {
 		didPath := buildDidPath(basepath, "did.json")
+		certPath := strings.TrimSuffix(basepath, "/") + "/.well-known/tls.crt"
 		logger.Info("Keycloak fixed realm server initialized",
 			zap.String("realm", realm),
 			zap.String("didPath", didPath),
+			zap.String("certPath", certPath),
 			zap.String("did", didID),
 		)
 		mux.HandleFunc(didPath, s.handlerRealm)
+		mux.HandleFunc(certPath, s.handlerCert)
 	}
 	return s
 }
@@ -169,28 +174,57 @@ func (s *DidServer) handleTlsCRT(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
-	var realm, didID string
-
+// resolveRealm returns the realm name: from the fixed config (fixed mode) or decoded from the path (dynamic mode).
+func (s *KeycloakServer) resolveRealm(r *http.Request) (string, error) {
 	if s.Realm != "" {
-		// Fixed mode: use pre-configured realm and DID.
-		realm = s.Realm
+		return s.Realm, nil
+	}
+	realmBase64 := r.PathValue("realm")
+	if realmBase64 == "" {
+		return "", fmt.Errorf("missing realm")
+	}
+	realmBytes, err := base64.StdEncoding.DecodeString(realmBase64)
+	if err != nil {
+		return "", fmt.Errorf("realm is not a valid base64 value")
+	}
+	return string(realmBytes), nil
+}
+
+// fetchJWKS fetches and decodes the JWKS from Keycloak for the given realm.
+// Returns the JWKS, an HTTP status code for error responses, and any error.
+func (s *KeycloakServer) fetchJWKS(realm string) (*JWKS, int, error) {
+	keycloakURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", s.KeycloakHost, realm)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: s.IgnoreTlsValidation},
+	}
+	client := http.Client{Timeout: 5 * time.Second, Transport: tr}
+	resp, err := client.Get(keycloakURL)
+	if err != nil {
+		return nil, http.StatusBadGateway, fmt.Errorf("identity provider unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, fmt.Errorf("realm not found or Keycloak error")
+	}
+	var jwks JWKS
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("invalid response from identity provider")
+	}
+	return &jwks, http.StatusOK, nil
+}
+
+func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
+	realm, err := s.resolveRealm(r)
+	if err != nil {
+		s.Logger.Warn("Could not resolve realm", zap.Error(err))
+		s.BaseServer.respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var didID string
+	if s.Realm != "" {
 		didID = s.DID
 	} else {
-		// Dynamic mode: realm is base64-encoded in the path.
-		realmBase64 := r.PathValue("realm")
-		if realmBase64 == "" {
-			s.Logger.Warn("Request received without realm")
-			http.Error(w, "Missing realm", http.StatusBadRequest)
-			return
-		}
-		realmBytes, err := base64.StdEncoding.DecodeString(realmBase64)
-		if err != nil {
-			s.Logger.Warn("Error decoding realm")
-			http.Error(w, "Realm is not a valid realm", http.StatusBadRequest)
-			return
-		}
-		realm = string(realmBytes)
 		host, _, err := net.SplitHostPort(r.Host)
 		if err != nil {
 			host = r.Host
@@ -198,36 +232,14 @@ func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
 		didID = fmt.Sprintf("did:web:%s:%s", host, realm)
 	}
 
-	keycloakURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", s.KeycloakHost, realm)
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: s.IgnoreTlsValidation},
-	}
-	client := http.Client{
-		Timeout:   5 * time.Second,
-		Transport: tr,
-	}
-	resp, err := client.Get(keycloakURL)
+	jwks, statusCode, err := s.fetchJWKS(realm)
 	if err != nil {
-		s.Logger.Error("Failed to connect to Keycloak", zap.Error(err), zap.String("url", keycloakURL))
-		s.BaseServer.respondWithError(w, http.StatusBadGateway, "Indentity provider unreachable")
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		s.Logger.Warn("Keycloak returned non-OK status", zap.Int("status", resp.StatusCode), zap.String("realm", realm))
-		s.BaseServer.respondWithError(w, resp.StatusCode, "Realm not found or Keycloak error")
+		s.Logger.Error("Failed to fetch JWKS", zap.Error(err), zap.String("realm", realm))
+		s.BaseServer.respondWithError(w, statusCode, err.Error())
 		return
 	}
 
-	var jwks JWKS
-	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-		s.Logger.Error("Failed to decode JWKS body", zap.Error(err))
-		s.BaseServer.respondWithError(w, http.StatusInternalServerError, "Invalid response from identity provider")
-		return
-	}
-
-	didDoc, err := s.Transformer.TransformJWKSToDIDByID(&jwks, didID)
+	didDoc, err := s.Transformer.TransformJWKSToDIDByID(jwks, didID)
 	if err != nil {
 		s.Logger.Warn("Transformation failed", zap.Error(err))
 		s.BaseServer.respondWithError(w, http.StatusNotFound, err.Error())
@@ -238,6 +250,37 @@ func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(didDoc); err != nil {
 		s.Logger.Error("Failed to encode JSON response", zap.Error(err))
 	}
+}
+
+func (s *KeycloakServer) handlerCert(w http.ResponseWriter, r *http.Request) {
+	realm, err := s.resolveRealm(r)
+	if err != nil {
+		s.Logger.Warn("Could not resolve realm", zap.Error(err))
+		s.BaseServer.respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	jwks, statusCode, err := s.fetchJWKS(realm)
+	if err != nil {
+		s.Logger.Error("Failed to fetch JWKS", zap.Error(err), zap.String("realm", realm))
+		s.BaseServer.respondWithError(w, statusCode, err.Error())
+		return
+	}
+
+	for _, key := range jwks.Keys {
+		if key.Use == "sig" && len(key.X5c) > 0 {
+			certDER, err := base64.StdEncoding.DecodeString(key.X5c[0])
+			if err != nil {
+				s.Logger.Error("Failed to decode x5c certificate", zap.Error(err))
+				s.BaseServer.respondWithError(w, http.StatusInternalServerError, "Invalid certificate in JWKS")
+				return
+			}
+			w.Header().Set("Content-Type", "application/x-x509-ca-cert")
+			w.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+			return
+		}
+	}
+	s.BaseServer.respondWithError(w, http.StatusNotFound, "No signing certificate found in JWKS")
 }
 
 func (s *BaseServer) Start() error {

--- a/did/server.go
+++ b/did/server.go
@@ -2,62 +2,20 @@ package did
 
 import (
 	"context"
-	"crypto/tls"
+	"encoding/json"
 	"fmt"
-	"log"
-	"net"
 	"net/http"
+	"os/signal"
 	"strings"
 	"syscall"
 	"time"
 
-	"os/signal"
-
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
-
 	"go.uber.org/zap"
 )
-
-type JWKS struct {
-	Keys []JWK `json:"keys"`
-}
-type JWK struct {
-	Kid     string   `json:"kid"`
-	Kty     string   `json:"kty"`
-	Alg     string   `json:"alg"`
-	Use     string   `json:"use"`
-	N       string   `json:"n,omitempty"`
-	E       string   `json:"e,omitempty"`
-	X5c     []string `json:"x5c"`
-	X5t     string   `json:"x5t"`
-	X5tS256 string   `json:"x5t#S256"`
-	Crv     string   `json:"crv,omitempty"`
-	X       string   `json:"x,omitempty"`
-	Y       string   `json:"y,omitempty"`
-}
 
 type BaseServer struct {
 	Server *http.Server
 	Logger *zap.Logger
-}
-type KeycloakServer struct {
-	BaseServer
-	KeycloakHost        string
-	Realm               string // fixed realm; empty means dynamic (read from path)
-	DID                 string // pre-computed DID ID for fixed realm mode
-	Transformer         *DIDTransformer
-	IgnoreTlsValidation bool
-}
-type DidServer struct {
-	BaseServer
-	DidJSONContent string
-	TlsCRTContent  string
-}
-type ErrorResponse struct {
-	Error   string `json:"error"`
-	Message string `json:"message"`
 }
 
 func buildDidPath(basepath, filename string) string {
@@ -68,252 +26,29 @@ func buildDidPath(basepath, filename string) string {
 	return basepath + "/" + filename
 }
 
-func NewDidServer(didJSON string, tlsCRT string, port int, basepath string, didFilename string) *DidServer {
-	logger, err := zap.NewProduction()
-	if err != nil {
-		log.Fatalf("Failed to initialize Zap logger: %v", err)
-	}
-	mux := http.NewServeMux()
-
-	didPath := buildDidPath(basepath, didFilename)
-	certPath := strings.TrimSuffix(basepath, "/") + "/.well-known/tls.crt"
-
-	s := &DidServer{
-		DidJSONContent: didJSON,
-		TlsCRTContent:  tlsCRT,
-		BaseServer: BaseServer{
-			Logger: logger,
-			Server: &http.Server{
-				Addr:         fmt.Sprintf(":%d", port),
-				Handler:      mux,
-				ReadTimeout:  5 * time.Second,
-				WriteTimeout: 10 * time.Second,
-			},
-		},
-	}
-	logger.Info("Base path: " + basepath)
-	logger.Info("Server initialized", zap.String("didPath", didPath), zap.String("certPath", certPath))
-	mux.HandleFunc(didPath, s.handleDidJSON)
-	mux.HandleFunc(certPath, s.handleTlsCRT)
-
-	return s
-}
-
-// NewKeycloakServer creates a Keycloak-backed DID server.
-// Dynamic mode (realm == ""): registers /{realm}/did.json; realm and DID are derived from each request.
-// Fixed mode (realm != ""): registers a static path from basepath and uses the pre-computed didID.
-func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool, realm, didID, basepath string) *KeycloakServer {
-	logger, err := zap.NewProduction()
-	if err != nil {
-		log.Fatalf("Failed to initialize Zap logger: %v", err)
-	}
-	if ignoreTlsValidation {
-		logger.Warn("Ignore TLS Validation is enabled. Do not use it in production")
-	}
-	mux := http.NewServeMux()
-	s := &KeycloakServer{
-		KeycloakHost:        keycloakHost,
-		Realm:               realm,
-		DID:                 didID,
-		Transformer:         NewDIDTransformer(logger),
-		IgnoreTlsValidation: ignoreTlsValidation,
-		BaseServer: BaseServer{
-			Logger: logger,
-			Server: &http.Server{
-				Addr:         fmt.Sprintf(":%d", port),
-				Handler:      mux,
-				ReadTimeout:  5 * time.Second,
-				WriteTimeout: 10 * time.Second,
-			},
-		},
-	}
-
-	if realm == "" {
-		mux.HandleFunc("/{realm}/did.json", s.handlerRealm)
-		mux.HandleFunc("/{realm}/.well-known/tls.crt", s.handlerCert)
-	} else {
-		didPath := buildDidPath(basepath, "did.json")
-		certPath := strings.TrimSuffix(basepath, "/") + "/.well-known/tls.crt"
-		logger.Info("Keycloak fixed realm server initialized",
-			zap.String("realm", realm),
-			zap.String("didPath", didPath),
-			zap.String("certPath", certPath),
-			zap.String("did", didID),
-		)
-		mux.HandleFunc(didPath, s.handlerRealm)
-		mux.HandleFunc(certPath, s.handlerCert)
-	}
-	return s
-}
-
-func (s *DidServer) handleDidJSON(w http.ResponseWriter, r *http.Request) {
-	// Log the incoming request details
-	s.Logger.Info("Request received",
-		zap.String("path", r.URL.Path),
-		zap.String("method", r.Method),
-		zap.String("remote_addr", r.RemoteAddr),
-	)
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(s.DidJSONContent)); err != nil {
-		s.Logger.Error("Error writing response for /did.json", zap.Error(err))
-	} else {
-		s.Logger.Debug("Response sent successfully", zap.Int("status", http.StatusOK))
-	}
-}
-
-func (s *DidServer) handleTlsCRT(w http.ResponseWriter, r *http.Request) {
-	s.Logger.Info("Request received", zap.String("path", r.URL.Path))
-
-	w.Header().Set("Content-Type", "application/x-x509-ca-cert")
-	w.WriteHeader(http.StatusOK)
-
-	if _, err := w.Write([]byte(s.TlsCRTContent)); err != nil {
-		s.Logger.Error("Error writing response for /tls.crt", zap.Error(err))
-	} else {
-		s.Logger.Debug("Response sent successfully", zap.Int("status", http.StatusOK))
-	}
-}
-
-// resolveRealm returns the realm name: from the fixed config (fixed mode) or decoded from the path (dynamic mode).
-func (s *KeycloakServer) resolveRealm(r *http.Request) (string, error) {
-	if s.Realm != "" {
-		return s.Realm, nil
-	}
-	realm := r.PathValue("realm")
-	if realm == "" {
-		return "", fmt.Errorf("missing realm")
-	}
-	return realm, nil
-}
-
-// fetchJWKS fetches and decodes the JWKS from Keycloak for the given realm.
-// Returns the JWKS, an HTTP status code for error responses, and any error.
-func (s *KeycloakServer) fetchJWKS(realm string) (*JWKS, int, error) {
-	keycloakURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", s.KeycloakHost, realm)
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: s.IgnoreTlsValidation},
-	}
-	client := http.Client{Timeout: 5 * time.Second, Transport: tr}
-	resp, err := client.Get(keycloakURL)
-	if err != nil {
-		return nil, http.StatusBadGateway, fmt.Errorf("identity provider unreachable: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, resp.StatusCode, fmt.Errorf("realm not found or Keycloak error")
-	}
-	var jwks JWKS
-	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-		return nil, http.StatusInternalServerError, fmt.Errorf("invalid response from identity provider")
-	}
-	return &jwks, http.StatusOK, nil
-}
-
-func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
-	realm, err := s.resolveRealm(r)
-	if err != nil {
-		s.Logger.Warn("Could not resolve realm", zap.Error(err))
-		s.BaseServer.respondWithError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	var didID string
-	if s.Realm != "" {
-		didID = s.DID
-	} else {
-		host, _, err := net.SplitHostPort(r.Host)
-		if err != nil {
-			host = r.Host
-		}
-		didID = fmt.Sprintf("did:web:%s:%s", host, realm)
-	}
-
-	jwks, statusCode, err := s.fetchJWKS(realm)
-	if err != nil {
-		s.Logger.Error("Failed to fetch JWKS", zap.Error(err), zap.String("realm", realm))
-		s.BaseServer.respondWithError(w, statusCode, err.Error())
-		return
-	}
-
-	didDoc, err := s.Transformer.TransformJWKSToDIDByID(jwks, didID)
-	if err != nil {
-		s.Logger.Warn("Transformation failed", zap.Error(err))
-		s.BaseServer.respondWithError(w, http.StatusNotFound, err.Error())
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(didDoc); err != nil {
-		s.Logger.Error("Failed to encode JSON response", zap.Error(err))
-	}
-}
-
-func (s *KeycloakServer) handlerCert(w http.ResponseWriter, r *http.Request) {
-	realm, err := s.resolveRealm(r)
-	if err != nil {
-		s.Logger.Warn("Could not resolve realm", zap.Error(err))
-		s.BaseServer.respondWithError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	jwks, statusCode, err := s.fetchJWKS(realm)
-	if err != nil {
-		s.Logger.Error("Failed to fetch JWKS", zap.Error(err), zap.String("realm", realm))
-		s.BaseServer.respondWithError(w, statusCode, err.Error())
-		return
-	}
-
-	for _, key := range jwks.Keys {
-		if key.Use == "sig" && len(key.X5c) > 0 {
-			certDER, err := base64.StdEncoding.DecodeString(key.X5c[0])
-			if err != nil {
-				s.Logger.Error("Failed to decode x5c certificate", zap.Error(err))
-				s.BaseServer.respondWithError(w, http.StatusInternalServerError, "Invalid certificate in JWKS")
-				return
-			}
-			w.Header().Set("Content-Type", "application/x-x509-ca-cert")
-			w.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
-			return
-		}
-	}
-	s.BaseServer.respondWithError(w, http.StatusNotFound, "No signing certificate found in JWKS")
-}
-
 func (s *BaseServer) Start() error {
 	s.Logger.Info("Starting server", zap.String("address", s.Server.Addr))
 
-	// Create context to listen for OS signals.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop() // Ensures context cancellation resource is released
+	defer stop()
 
-	// 1. Run the server in a goroutine
 	go func() {
 		if err := s.Server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			// Use Zap logger for the fatal start error
 			s.Logger.Fatal("Could not start server listener", zap.Error(err))
 		}
 	}()
 
-	// Sync the logger before exiting, ensuring all buffered logs are written.
-	// This defer is placed here to ensure it runs when the function exits (after shutdown).
 	defer s.Logger.Sync()
 
-	// 2. Block until context is canceled (i.e., SIGTERM/SIGINT is received)
 	<-ctx.Done()
 
-	// 3. Graceful Shutdown initiated
 	s.Logger.Info("Shutdown signal received. Initiating graceful shutdown...")
 
-	// 4. Create a timeout context for the shutdown (e.g., 10 seconds)
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Execute the graceful shutdown
 	if err := s.Shutdown(shutdownCtx); err != nil {
 		s.Logger.Error("Server forced to shutdown after timeout", zap.Error(err))
-		// Kubernetes will still kill the pod, but we log the forced shutdown.
 		return fmt.Errorf("server shutdown error: %w", err)
 	}
 

--- a/did/server.go
+++ b/did/server.go
@@ -42,6 +42,8 @@ type BaseServer struct {
 type KeycloakServer struct {
 	BaseServer
 	KeycloakHost        string
+	Realm               string // fixed realm; empty means dynamic (read from path)
+	DID                 string // pre-computed DID ID for fixed realm mode
 	Transformer         *DIDTransformer
 	IgnoreTlsValidation bool
 }
@@ -55,22 +57,23 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
+func buildDidPath(basepath, filename string) string {
+	basepath = strings.TrimSuffix(basepath, "/")
+	if basepath == "" {
+		return "/.well-known/" + filename
+	}
+	return basepath + "/" + filename
+}
+
 func NewDidServer(didJSON string, tlsCRT string, port int, basepath string, didFilename string) *DidServer {
 	logger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logger: %v", err)
 	}
-	basepath = strings.TrimSuffix(basepath, "/")
 	mux := http.NewServeMux()
 
-	var didPath string
-	var certPath = basepath + "/.well-known/tls.crt"
-	// Ensure basepath has no trailing slash
-	if basepath == "" {
-		didPath = "/.well-known/" + didFilename
-	} else {
-		didPath = basepath + "/" + didFilename
-	}
+	didPath := buildDidPath(basepath, didFilename)
+	certPath := strings.TrimSuffix(basepath, "/") + "/.well-known/tls.crt"
 
 	s := &DidServer{
 		DidJSONContent: didJSON,
@@ -93,8 +96,10 @@ func NewDidServer(didJSON string, tlsCRT string, port int, basepath string, didF
 	return s
 }
 
-func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool) *KeycloakServer {
-
+// NewKeycloakServer creates a Keycloak-backed DID server.
+// Dynamic mode (realm == ""): registers /{realm}/did.json; realm and DID are derived from each request.
+// Fixed mode (realm != ""): registers a static path from basepath and uses the pre-computed didID.
+func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool, realm, didID, basepath string) *KeycloakServer {
 	logger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logger: %v", err)
@@ -105,6 +110,8 @@ func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool) 
 	mux := http.NewServeMux()
 	s := &KeycloakServer{
 		KeycloakHost:        keycloakHost,
+		Realm:               realm,
+		DID:                 didID,
 		Transformer:         NewDIDTransformer(),
 		IgnoreTlsValidation: ignoreTlsValidation,
 		BaseServer: BaseServer{
@@ -118,7 +125,17 @@ func NewKeycloakServer(keycloakHost string, port int, ignoreTlsValidation bool) 
 		},
 	}
 
-	mux.HandleFunc("/{realm}/did.json", s.handlerRealm)
+	if realm == "" {
+		mux.HandleFunc("/{realm}/did.json", s.handlerRealm)
+	} else {
+		didPath := buildDidPath(basepath, "did.json")
+		logger.Info("Keycloak fixed realm server initialized",
+			zap.String("realm", realm),
+			zap.String("didPath", didPath),
+			zap.String("did", didID),
+		)
+		mux.HandleFunc(didPath, s.handlerRealm)
+	}
 	return s
 }
 
@@ -153,23 +170,36 @@ func (s *DidServer) handleTlsCRT(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
+	var realm, didID string
 
-	realmBase64 := r.PathValue("realm")
-	if realmBase64 == "" {
-		s.Logger.Warn("Request received without realm")
-		http.Error(w, "Missing realm", http.StatusBadRequest)
-		return
+	if s.Realm != "" {
+		// Fixed mode: use pre-configured realm and DID.
+		realm = s.Realm
+		didID = s.DID
+	} else {
+		// Dynamic mode: realm is base64-encoded in the path.
+		realmBase64 := r.PathValue("realm")
+		if realmBase64 == "" {
+			s.Logger.Warn("Request received without realm")
+			http.Error(w, "Missing realm", http.StatusBadRequest)
+			return
+		}
+		realmBytes, err := base64.StdEncoding.DecodeString(realmBase64)
+		if err != nil {
+			s.Logger.Warn("Error decoding realm")
+			http.Error(w, "Realm is not a valid realm", http.StatusBadRequest)
+			return
+		}
+		realm = string(realmBytes)
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			host = r.Host
+		}
+		didID = fmt.Sprintf("did:web:%s:%s", host, realm)
 	}
-	realmBytes, err := base64.StdEncoding.DecodeString(realmBase64)
-	if err != nil {
-		s.Logger.Warn("Error decoding realm")
-		http.Error(w, "Realm is not a valid realm", http.StatusBadRequest)
-		return
-	}
-	realm := string(realmBytes)
+
 	keycloakURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", s.KeycloakHost, realm)
 	tr := &http.Transport{
-		// Configuración de TLS para ignorar la verificación
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: s.IgnoreTlsValidation},
 	}
 	client := http.Client{
@@ -197,11 +227,7 @@ func (s *KeycloakServer) handlerRealm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	host, _, err := net.SplitHostPort(r.Host)
-	if err != nil {
-		host = r.Host
-	}
-	didDoc, err := s.Transformer.TransformJWKSToDID(&jwks, host, realm)
+	didDoc, err := s.Transformer.TransformJWKSToDIDByID(&jwks, didID)
 	if err != nil {
 		s.Logger.Warn("Transformation failed", zap.Error(err))
 		s.BaseServer.respondWithError(w, http.StatusNotFound, err.Error())

--- a/did/types.go
+++ b/did/types.go
@@ -1,0 +1,25 @@
+package did
+
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+type JWK struct {
+	Kid     string   `json:"kid"`
+	Kty     string   `json:"kty"`
+	Alg     string   `json:"alg"`
+	Use     string   `json:"use"`
+	N       string   `json:"n,omitempty"`
+	E       string   `json:"e,omitempty"`
+	X5c     []string `json:"x5c"`
+	X5t     string   `json:"x5t"`
+	X5tS256 string   `json:"x5t#S256"`
+	Crv     string   `json:"crv,omitempty"`
+	X       string   `json:"x,omitempty"`
+	Y       string   `json:"y,omitempty"`
+}
+
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,7 @@ STORE_PASS="${STORE_PASS:-changeit}"
 
 cd /cert
 
-if [[ -z "${KEYSTORE_PATH:-}" ]] && [[ -z "${CERT_URL:-}" ]]; then
+if [[ -z "${KEYSTORE_PATH:-}" ]] && [[ -z "${CERT_URL:-}" ]] && [[ -z "${KEYCLOAK_HOST:-}" ]]; then
   case "$KEY_TYPE_TO_GENERATE" in
     EC)
       case "$KEY_TYPE" in

--- a/main.go
+++ b/main.go
@@ -32,9 +32,11 @@ func main() {
 	}
 	flag.Parse()
 
-	err = did.LoadCertificates(&cfg)
-	if err != nil {
-		os.Exit(1)
+	if cfg.DidType != "keycloak" {
+		err = did.LoadCertificates(&cfg)
+		if err != nil {
+			os.Exit(1)
+		}
 	}
 	switch cfg.DidType {
 	case "key":
@@ -43,6 +45,8 @@ func main() {
 		resultingDid, err = did.GetDIDJWKFromKey(cfg)
 	case "web":
 		resultingDid, err = did.GetDIDWeb(cfg.HostUrl)
+	case "keycloak":
+		resultingDid = ""
 	default:
 		zap.L().Sugar().Warnf("Did type %s is not supported.", cfg.DidType)
 		os.Exit(2)
@@ -51,7 +55,7 @@ func main() {
 	if err != nil {
 		fmt.Println("Was not able to extract did. Err: ", err)
 		os.Exit(3)
-	} else {
+	} else if resultingDid != "" {
 		fmt.Println("Did key is: ", resultingDid)
 	}
 
@@ -90,20 +94,25 @@ func main() {
 			os.Exit(7)
 		}
 	} else if cfg.RunServer {
-		// Error is detected genering the content
-		cert, _ := did.GetCert(cfg)
-		webUrl, err := url.Parse(cfg.HostUrl)
-		if err != nil {
-			zap.L().Sugar().Errorf("'%s' is not a valid url")
-			os.Exit(7)
-		}
-		didFilename := "did.json"
-		if cfg.OutputFormat == "env" {
-			didFilename = "did.env"
-		}
+		if cfg.DidType == "keycloak" {
+			server := did.NewKeycloakServer(cfg.KeycloakHost, cfg.ServerPort, cfg.IgnoreTlsValidation)
+			server.BaseServer.Start()
+		} else {
+			cert, _ := did.GetCert(cfg)
+			webUrl, err := url.Parse(cfg.HostUrl)
+			if err != nil {
+				zap.L().Sugar().Errorf("'%s' is not a valid url")
+				os.Exit(7)
+			}
+			didFilename := "did.json"
+			if cfg.OutputFormat == "env" {
+				didFilename = "did.env"
+			}
 
-		server := did.NewDidServer(string(fileContent), string(cert), cfg.ServerPort, webUrl.Path, didFilename)
-		server.Start()
+			server := did.NewDidServer(string(fileContent), string(cert), cfg.ServerPort, webUrl.Path, didFilename)
+			server.Start()
+
+		}
 	} else {
 		fmt.Println("Output: ", string(fileContent))
 	}

--- a/main.go
+++ b/main.go
@@ -18,110 +18,119 @@ func init() {
 	zap.ReplaceGlobals(zap.Must(zap.NewDevelopment()))
 }
 
-func getHostPath(hostUrl string) string {
+func getHostPath(hostUrl string) (string, error) {
 	webUrl, err := url.Parse(hostUrl)
 	if err != nil {
-		zap.L().Sugar().Errorf("'%s' is not a valid url", hostUrl)
-		os.Exit(7)
+		return "", fmt.Errorf("'%s' is not a valid url", hostUrl)
 	}
-	return webUrl.Path
+	return webUrl.Path, nil
 }
 
-func main() {
-	var cfg did.Config
-	var fileContent []byte
-	var resultingDid string
-	var err error
-
-	filler := flagsfiller.New(flagsfiller.WithEnv(""))
-	err = filler.Fill(flag.CommandLine, &cfg)
-	if err != nil {
-		zap.L().Sugar().Fatal("error reading config. error %s", err)
-		os.Exit(1)
-	}
-	flag.Parse()
-
-	if cfg.DidType != "keycloak" {
-		err = did.LoadCertificates(&cfg)
-		if err != nil {
-			os.Exit(1)
-		}
-	}
+func resolveDID(cfg did.Config) (string, error) {
 	switch cfg.DidType {
 	case "key":
-		resultingDid, err = did.GetDIDKey(cfg)
+		return did.GetDIDKey(cfg)
 	case "jwk":
-		resultingDid, err = did.GetDIDJWKFromKey(cfg)
+		return did.GetDIDJWKFromKey(cfg)
 	case "web":
-		resultingDid, err = did.GetDIDWeb(cfg.HostUrl)
+		return did.GetDIDWeb(cfg.HostUrl)
 	case "keycloak":
 		if cfg.KeycloakRealm != "" {
-			resultingDid, err = did.GetDIDWeb(cfg.HostUrl)
+			return did.GetDIDWeb(cfg.HostUrl)
 		}
+		return "", nil
 	default:
-		zap.L().Sugar().Warnf("Did type %s is not supported.", cfg.DidType)
-		os.Exit(2)
+		return "", fmt.Errorf("did type %s is not supported", cfg.DidType)
 	}
+}
 
-	if err != nil {
-		fmt.Println("Was not able to extract did. Err: ", err)
-		os.Exit(3)
-	} else if resultingDid != "" {
-		fmt.Println("Did key is: ", resultingDid)
-	}
-
+func buildOutput(cfg *did.Config, resultingDid string) ([]byte, error) {
 	switch cfg.OutputFormat {
 	case "json":
 		didJson := did.Did{IssuerDid: []string{"https://www.w3.org/ns/did/v1"}, Id: resultingDid}
-		fileContent, err = json.Marshal(didJson)
-		if err != nil {
-			zap.L().Sugar().Warnf("Was not able to marshal the did-json. Err: %s", err)
-			os.Exit(4)
-		}
+		return json.Marshal(didJson)
 	case "env":
-		fileContent = ([]byte("DID=" + resultingDid))
+		return []byte("DID=" + resultingDid), nil
 	case "json_jwk":
 		if cfg.CertUrl == "" {
 			cfg.CertUrl = strings.TrimSuffix(cfg.HostUrl, "/") + "/.well-known/tls.crt"
 		}
-		keySet, err := did.GenerateJWK(cfg)
+		keySet, err := did.GenerateJWK(*cfg)
 		if err != nil {
-			zap.L().Sugar().Warnf("Error generating keyset. Err: %s", err)
-			os.Exit(5)
+			return nil, fmt.Errorf("error generating keyset: %w", err)
 		}
 		verificationMethod := did.VerificationMethod{Id: resultingDid, Type: "JsonWebKey2020", Controller: resultingDid, PublicKeyJwk: keySet}
 		didJson := did.Did{Context: []string{"https://www.w3.org/ns/did/v1"}, Id: resultingDid, VerificationMethod: []did.VerificationMethod{verificationMethod}}
-		fileContent, err = json.MarshalIndent(didJson, "", "  ")
-		if err != nil {
-			zap.L().Sugar().Warnf("Error printing keyset")
-			os.Exit(6)
+		return json.MarshalIndent(didJson, "", "  ")
+	}
+	return nil, nil
+}
+
+func startServer(cfg did.Config, fileContent []byte, resultingDid string) error {
+	if cfg.DidType == "keycloak" {
+		var basepath string
+		if cfg.KeycloakRealm != "" {
+			var err error
+			basepath, err = getHostPath(cfg.HostUrl)
+			if err != nil {
+				return err
+			}
+		}
+		server := did.NewKeycloakServer(cfg.KeycloakHost, cfg.ServerPort, cfg.IgnoreTlsValidation, cfg.KeycloakRealm, resultingDid, basepath)
+		return server.Start()
+	}
+
+	cert, _ := did.GetCert(cfg)
+	didFilename := "did.json"
+	if cfg.OutputFormat == "env" {
+		didFilename = "did.env"
+	}
+	hostPath, err := getHostPath(cfg.HostUrl)
+	if err != nil {
+		return err
+	}
+	server := did.NewDidServer(string(fileContent), string(cert), cfg.ServerPort, hostPath, didFilename)
+	return server.Start()
+}
+
+func main() {
+	var cfg did.Config
+
+	filler := flagsfiller.New(flagsfiller.WithEnv(""))
+	if err := filler.Fill(flag.CommandLine, &cfg); err != nil {
+		zap.L().Sugar().Fatalf("error reading config: %s", err)
+	}
+	flag.Parse()
+
+	if cfg.DidType != "keycloak" {
+		if err := did.LoadCertificates(&cfg); err != nil {
+			os.Exit(1)
 		}
 	}
-	if cfg.OutputFile != "" {
 
-		err = os.WriteFile(cfg.OutputFile, fileContent, 0644)
-		if err != nil {
-			zap.L().Sugar().Warnf("Was not able to write the did-json to %s. Err: %s", cfg.OutputFile, err)
-			os.Exit(7)
+	resultingDid, err := resolveDID(cfg)
+	if err != nil {
+		zap.L().Sugar().Fatalf("was not able to resolve did: %s", err)
+	}
+	if resultingDid != "" {
+		fmt.Println("Did key is: ", resultingDid)
+	}
+
+	fileContent, err := buildOutput(&cfg, resultingDid)
+	if err != nil {
+		zap.L().Sugar().Fatalf("was not able to build output: %s", err)
+	}
+
+	switch {
+	case cfg.OutputFile != "":
+		if err := os.WriteFile(cfg.OutputFile, fileContent, 0644); err != nil {
+			zap.L().Sugar().Fatalf("was not able to write to %s: %s", cfg.OutputFile, err)
 		}
-	} else if cfg.RunServer {
-		if cfg.DidType == "keycloak" {
-			var basepath string
-			if cfg.KeycloakRealm != "" {
-				basepath = getHostPath(cfg.HostUrl)
-			}
-			server := did.NewKeycloakServer(cfg.KeycloakHost, cfg.ServerPort, cfg.IgnoreTlsValidation, cfg.KeycloakRealm, resultingDid, basepath)
-			server.BaseServer.Start()
-		} else {
-			cert, _ := did.GetCert(cfg)
-			didFilename := "did.json"
-			if cfg.OutputFormat == "env" {
-				didFilename = "did.env"
-			}
-			server := did.NewDidServer(string(fileContent), string(cert), cfg.ServerPort, getHostPath(cfg.HostUrl), didFilename)
-			server.Start()
+	case cfg.RunServer:
+		if err := startServer(cfg, fileContent, resultingDid); err != nil {
+			zap.L().Sugar().Fatalf("server error: %s", err)
 		}
-	} else {
+	default:
 		fmt.Println("Output: ", string(fileContent))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,15 @@ func init() {
 	zap.ReplaceGlobals(zap.Must(zap.NewDevelopment()))
 }
 
+func getHostPath(hostUrl string) string {
+	webUrl, err := url.Parse(hostUrl)
+	if err != nil {
+		zap.L().Sugar().Errorf("'%s' is not a valid url", hostUrl)
+		os.Exit(7)
+	}
+	return webUrl.Path
+}
+
 func main() {
 	var cfg did.Config
 	var fileContent []byte
@@ -46,7 +55,9 @@ func main() {
 	case "web":
 		resultingDid, err = did.GetDIDWeb(cfg.HostUrl)
 	case "keycloak":
-		resultingDid = ""
+		if cfg.KeycloakRealm != "" {
+			resultingDid, err = did.GetDIDWeb(cfg.HostUrl)
+		}
 	default:
 		zap.L().Sugar().Warnf("Did type %s is not supported.", cfg.DidType)
 		os.Exit(2)
@@ -95,23 +106,20 @@ func main() {
 		}
 	} else if cfg.RunServer {
 		if cfg.DidType == "keycloak" {
-			server := did.NewKeycloakServer(cfg.KeycloakHost, cfg.ServerPort, cfg.IgnoreTlsValidation)
+			var basepath string
+			if cfg.KeycloakRealm != "" {
+				basepath = getHostPath(cfg.HostUrl)
+			}
+			server := did.NewKeycloakServer(cfg.KeycloakHost, cfg.ServerPort, cfg.IgnoreTlsValidation, cfg.KeycloakRealm, resultingDid, basepath)
 			server.BaseServer.Start()
 		} else {
 			cert, _ := did.GetCert(cfg)
-			webUrl, err := url.Parse(cfg.HostUrl)
-			if err != nil {
-				zap.L().Sugar().Errorf("'%s' is not a valid url")
-				os.Exit(7)
-			}
 			didFilename := "did.json"
 			if cfg.OutputFormat == "env" {
 				didFilename = "did.env"
 			}
-
-			server := did.NewDidServer(string(fileContent), string(cert), cfg.ServerPort, webUrl.Path, didFilename)
+			server := did.NewDidServer(string(fileContent), string(cert), cfg.ServerPort, getHostPath(cfg.HostUrl), didFilename)
 			server.Start()
-
 		}
 	} else {
 		fmt.Println("Output: ", string(fileContent))


### PR DESCRIPTION
Adds the option to deploy the server so it can read keys directly from Keycloak. Keycloak provides a way to generate keys but does not allow exporting them. With this new method, the server can read DIDs in the format did:url:{realmIdBase64} to retrieve the corresponding did.json. This ensures secure access to the keys without requiring manual export from Keycloak.

It can also use a static realm and the `hostUrl` to expose the DID based on that realm.